### PR TITLE
chore: updates image tags from latest to stable and edge to latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,25 +18,6 @@ platforms: &platforms
 
 workflows:
 
-  build_edge:
-    jobs:
-      - build:
-          stream: edge
-          context: docker-publishing
-          matrix:
-            parameters:
-              executor: *platforms
-          filters:
-            branches:
-              only: [ main ]
-      - manifest:
-          stream: edge
-          context: docker-publishing
-          requires: [ build ]
-          filters:
-            branches:
-              only: [ main ]
-
   build_latest:
     jobs:
       - build:
@@ -47,25 +28,44 @@ workflows:
               executor: *platforms
           filters:
             branches:
-              only: [ releases ]
+              only: [ main ]
       - manifest:
           stream: latest
           context: docker-publishing
           requires: [ build ]
           filters:
             branches:
-              only: [ releases ]
+              only: [ main ]
 
-  nightly_edge:
+  build_stable:
     jobs:
       - build:
-          stream: edge
+          stream: stable
+          context: docker-publishing
+          matrix:
+            parameters:
+              executor: *platforms
+          filters:
+            branches:
+              only: [ releases ]
+      - manifest:
+          stream: stable
+          context: docker-publishing
+          requires: [ build ]
+          filters:
+            branches:
+              only: [ releases ]
+
+  nightly_latest:
+    jobs:
+      - build:
+          stream: latest
           context: docker-publishing
           matrix:
             parameters:
               executor: *platforms
       - manifest:
-          stream: edge
+          stream: latest
           context: docker-publishing
           requires: [ build ]
           filters:
@@ -79,16 +79,16 @@ workflows:
             branches:
               only: [ main ]
 
-  nightly_latest:
+  nightly_stable:
     jobs:
       - build:
-          stream: latest
+          stream: stable
           context: docker-publishing
           matrix:
             parameters:
               executor: *platforms
       - manifest:
-          stream: latest
+          stream: stable
           context: docker-publishing
           requires: [ build ]
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,10 +18,10 @@ platforms: &platforms
 
 workflows:
 
-  build_latest:
+  build_edge:
     jobs:
       - build:
-          stream: latest
+          stream: edge
           context: docker-publishing
           matrix:
             parameters:
@@ -30,7 +30,7 @@ workflows:
             branches:
               only: [ main ]
       - manifest:
-          stream: latest
+          stream: edge
           context: docker-publishing
           requires: [ build ]
           filters:
@@ -56,7 +56,7 @@ workflows:
             branches:
               only: [ releases ]
 
-  nightly_latest:
+  build_latest:
     jobs:
       - build:
           stream: latest
@@ -64,8 +64,27 @@ workflows:
           matrix:
             parameters:
               executor: *platforms
+          filters:
+            branches:
+              only: [ releases ]
       - manifest:
           stream: latest
+          context: docker-publishing
+          requires: [ build ]
+          filters:
+            branches:
+              only: [ releases ]
+
+  nightly_edge:
+    jobs:
+      - build:
+          stream: edge
+          context: docker-publishing
+          matrix:
+            parameters:
+              executor: *platforms
+      - manifest:
+          stream: edge
           context: docker-publishing
           requires: [ build ]
           filters:
@@ -89,6 +108,29 @@ workflows:
               executor: *platforms
       - manifest:
           stream: stable
+          context: docker-publishing
+          requires: [ build ]
+          filters:
+            branches:
+              only: [ releases ]
+    triggers:
+      - schedule:
+          # Scheduled build for 2am AEST nightly.
+          cron: "0 15 * * *"
+          filters:
+            branches:
+              only: [ releases ]
+
+  nightly_latest:
+    jobs:
+      - build:
+          stream: latest
+          context: docker-publishing
+          matrix:
+            parameters:
+              executor: *platforms
+      - manifest:
+          stream: latest
           context: docker-publishing
           requires: [ build ]
           filters:


### PR DESCRIPTION
## Overview

Update Image tags from `edge` to `latest` and update `latest` to `stable`

## Implementation

I've updated the image tags and even stage names to reflect the change

## How to Test

Running the build pipeline will build the tags as intended

## What is the rollout plan?

We need to update skpr to use the new image tags and for those projects not on skpr update their pipelines. 

## Does this change need a blog post?

No

## Link to Tickets

* https://previousnext.atlassian.net/browse/SKPR-958 