### PR TITLE
[SKPR-494] feat: enable ScanPE

### DIFF
--- a/dev/clamd.conf
+++ b/dev/clamd.conf
@@ -25,7 +25,7 @@ DatabaseDirectory /var/lib/clamav
 SelfCheck 3600
 Foreground true
 Debug true # This is what has been enabled for dev.
-ScanPE false
+ScanPE true
 ScanOLE2 true
 ScanHTML true
 ExitOnOOM true


### PR DESCRIPTION
What is ScanPE:
PE stands for Portable Executable - it's an executable file format used in all 32 and 64-bit versions of Windows operating systems. This option allows ClamAV to perform a deeper analysis of executable files and it's also required for decompression of popular executable packers such as UPX. 

Purpose:
This config change enables ClamAV to scan portable executable files in a filesystem. 